### PR TITLE
update to the base image to the latest version of denismakogon/ffmpeg…

### DIFF
--- a/build-stage/Dockerfile
+++ b/build-stage/Dockerfile
@@ -1,4 +1,4 @@
-FROM denismakogon/ffmpeg-alpine:4.0-golang
+FROM denismakogon/ffmpeg-alpine:4.0-golang-1.11
 
 LABEL maintainer="Denis Makogon. mail: lildee1991@gmail.com"
 


### PR DESCRIPTION
…-alpine

to be able to use Go1.13 and benefit from the latest features (many dependencies nowadays require at least Go1.12), the base image needs to be updated, unless it is kept like that for some reason. Once the build-stage is built, and pushed to docker hub, we can update the runtime image as well. 

PS: `denismakogon/ffmpeg-alpine:4.0-golang-1.11` uses golang 1.13. The name is a bit misleading:)

 